### PR TITLE
Fix device validation and check interval

### DIFF
--- a/led_matrix_battery/led_matrix/helpers/device.py
+++ b/led_matrix_battery/led_matrix/helpers/device.py
@@ -64,7 +64,7 @@ def check_device(device):
         raise TypeError(emsg)
 
     # Both the vendor and product ID must match to be supported
-    if device.vid != 0x32AC or device.pid != 0x20:
+    if device.vid != EXPECTED_VID or device.pid != EXPECTED_PID:
         log.warning(
             f'Given device is not supported. (VID: {device.vid}, PID: {device.pid})'
         )

--- a/led_matrix_battery/led_matrix/helpers/device.py
+++ b/led_matrix_battery/led_matrix/helpers/device.py
@@ -63,8 +63,11 @@ def check_device(device):
         log.error(emsg)
         raise TypeError(emsg)
 
-    if device.vid != 0x32AC and device.pid == 0x20:
-        log.warning(f'Given device is not supported. (VID: {device.vid}, PID: {device.pid})')
+    # Both the vendor and product ID must match to be supported
+    if device.vid != 0x32AC or device.pid != 0x20:
+        log.warning(
+            f'Given device is not supported. (VID: {device.vid}, PID: {device.pid})'
+        )
         return False
 
     return bool(test_connection(device.device))

--- a/led_matrix_battery/monitor/__init__.py
+++ b/led_matrix_battery/monitor/__init__.py
@@ -76,7 +76,8 @@ class PowerMonitor(Loggable):
             self.unplugged_alert = unplugged_alert
 
         self.dev.brightness = percentage_to_value(5)
-        self.__battery_check_interval = battery_check_interval or self.__check_interval
+        # Respect user-provided interval when initializing
+        self.battery_check_interval = battery_check_interval or self.__check_interval
 
     @property
     def battery_check_interval(self):


### PR DESCRIPTION
## Summary
- respect user provided battery check interval when initializing PowerMonitor
- correct device VID/PID validation logic

## Testing
- `python -m compileall -q led_matrix_battery` *(fails: IndentationError)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6842258c3858832d8dbc323931d8e4fb

## Summary by Sourcery

Fix device validation and ensure user-provided battery check interval is respected

Bug Fixes:
- Correct device VID/PID validation to require both IDs to match
- Respect user-provided battery check interval when initializing PowerMonitor