### PR TITLE
Return thread from monitor thread helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ device = DEVICES[0]
 
 # Start monitoring in a background thread
 monitor = run_power_monitor_threaded(device)
+# ``monitor`` is a :class:`threading.Thread` instance
 ```
 
 ## Troubleshooting

--- a/led_matrix_battery/monitor/__init__.py
+++ b/led_matrix_battery/monitor/__init__.py
@@ -347,6 +347,19 @@ def run_power_monitor(
 def run_power_monitor_threaded(
         *args,
         **kwargs
-) -> PowerMonitor:
+) -> Thread:
+    """Run :func:`run_power_monitor` in a background thread.
+
+    Parameters
+    ----------
+    *args, **kwargs
+        Arguments passed directly to :func:`run_power_monitor`.
+
+    Returns
+    -------
+    Thread
+        The thread running the monitor.
+    """
     monitor = Thread(target=run_power_monitor, args=args, kwargs=kwargs)
     monitor.start()
+    return monitor


### PR DESCRIPTION
## Summary
- return `Thread` from `run_power_monitor_threaded`
- document return value in README

## Testing
- `python -m py_compile led_matrix_battery/monitor/__init__.py`

------
https://chatgpt.com/codex/tasks/task_e_6842380ae678832d907231dee0124518

## Summary by Sourcery

Return the monitoring thread object from run_power_monitor_threaded and update documentation to reflect the change.

Enhancements:
- Change run_power_monitor_threaded to return the started Thread instance
- Add docstring for run_power_monitor_threaded specifying its Thread return value

Documentation:
- Document the Thread return value in README usage example