### PR TITLE
Fix GitHub API header

### DIFF
--- a/Scripts/install_presets.py
+++ b/Scripts/install_presets.py
@@ -16,7 +16,7 @@ LOGGER = InspyLogger('LEDMatrixLib:PresetInstaller', console_level='debug', no_f
 API_URL = PROJECT_URLS['github_api']
 
 REQ_HEADERS = {
-    "Accept": "application./vnd.github.v3+json"
+    "Accept": "application/vnd.github.v3+json"
 }
 
 REPO_PRESETS_URL          = assemble_url('presets')


### PR DESCRIPTION
## Summary
- correct Accept header in `install_presets.py`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684238c71f60832daa13f055bb359146

## Summary by Sourcery

Bug Fixes:
- Correct the Accept header value to use the proper GitHub v3 JSON media type